### PR TITLE
Lower minimum cmake version to 3.10.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10.2)
 
 project(protobuf_comm VERSION 0.9.0
   DESCRIPTION "Protobuf wrapper for peer-to-peer communication")


### PR DESCRIPTION
ROS melodic ships with cmake 3.10.2, since there is no problem building this package with cmake 3.10.2 I lowered it.