### PR TITLE
client: disconnect only if not cancelled explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)
 
-project(protobuf_comm VERSION 0.9.1
+project(protobuf_comm VERSION 0.9.2
   DESCRIPTION "Protobuf wrapper for peer-to-peer communication")
 
 find_package(Protobuf REQUIRED)

--- a/client.cpp
+++ b/client.cpp
@@ -177,7 +177,7 @@ ProtobufStreamClient::handle_resolve(const boost::system::error_code &err,
 		                           boost::bind(&ProtobufStreamClient::handle_connect,
 		                                       this,
 		                                       boost::asio::placeholders::error));
-	} else {
+	} else if (err != boost::asio::error::operation_aborted) {
 		disconnect_nosig();
 		sig_disconnected_(err);
 	}
@@ -214,6 +214,7 @@ ProtobufStreamClient::disconnect_nosig()
 {
 	boost::system::error_code err;
 	if (socket_.is_open()) {
+		socket_.cancel();
 		socket_.shutdown(ip::tcp::socket::shutdown_both, err);
 		socket_.close();
 	}
@@ -266,7 +267,7 @@ ProtobufStreamClient::handle_read_header(const boost::system::error_code &error)
 		                        boost::bind(&ProtobufStreamClient::handle_read_message,
 		                                    this,
 		                                    boost::asio::placeholders::error));
-	} else {
+	} else if (error != boost::asio::error::operation_aborted) {
 		disconnect_nosig();
 		sig_disconnected_(error);
 	}
@@ -311,7 +312,7 @@ ProtobufStreamClient::handle_read_message(const boost::system::error_code &error
 		}
 
 		start_recv();
-	} else {
+	} else if (error != boost::asio::error::operation_aborted) {
 		disconnect_nosig();
 		sig_disconnected_(error);
 	}
@@ -348,7 +349,7 @@ ProtobufStreamClient::handle_write(const boost::system::error_code &error,
 		} else {
 			outbound_active_ = false;
 		}
-	} else {
+	} else if (error != boost::asio::error::operation_aborted) {
 		disconnect_nosig();
 		sig_disconnected_(error);
 	}


### PR DESCRIPTION
We encountered funny errors when using the client.
Basically, while disconnecting gracefully (via destructor), the running async tasks were causing a double closing of the socket and bogus errors.
To fix this, only stop the socket in the async tasks if the error is not the explicit cancellation of the socket.